### PR TITLE
Downgrade meta and increate minimum Dart version

### DIFF
--- a/.github/workflows/pana.yml
+++ b/.github/workflows/pana.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         package:
           - 'wakelock_plus'
-          - 'wakelock_platform_interface'
+          - 'wakelock_plus_platform_interface'
       fail-fast: false
 
     steps:

--- a/wakelock_plus/CHANGELOG.md
+++ b/wakelock_plus/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0
+
+* [#2](https://github.com/fluttercommunity/wakelock_plus/pull/2): Downgraded minimum `meta` to version `1.3.0` in order to maintain compatibility with versions of Flutter below `3.10`. 
+  Also downgraded `js` to version `0.6.3` due to the above. Thanks [diegotori](https://github.com/diegotori).
+* **BREAKING CHANGE**: Increased the minimum supported Dart version to `2.18` in order to align it with `wakelock_plus_platform_interface` version `1.1.0`.
+
 ## 1.0.0+3
 
 * `README.md` now attributes the original author of the `wakelock` plugin, which this plugin is based on.

--- a/wakelock_plus/pubspec.yaml
+++ b/wakelock_plus/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0+3
 repository: https://github.com/fluttercommunity/wakelock_plus/tree/main/wakelock_plus
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.18.0 <4.0.0'
   flutter: ">=3.3.0"
 
 dependencies:
@@ -14,8 +14,8 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.9.1
-  wakelock_plus_platform_interface: ^1.0.0
+  meta: ^1.3.0
+  wakelock_plus_platform_interface: ^1.1.0
 
   # Windows dependencies
   # win32 is compatible across v4 and v5 for Win32 only (not COM)
@@ -26,7 +26,7 @@ dependencies:
   package_info_plus: ^4.0.2
 
   # Web dependencies
-  js: ^0.6.7
+  js: ^0.6.3
 
 dev_dependencies:
   flutter_test:

--- a/wakelock_plus/pubspec.yaml
+++ b/wakelock_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: wakelock_plus
 description: >-2
   Plugin that allows you to keep the device screen awake, i.e. prevent the screen from sleeping on
   Android, iOS, macOS, Windows, Linux, and web.
-version: 1.0.0+3
+version: 1.1.0
 repository: https://github.com/fluttercommunity/wakelock_plus/tree/main/wakelock_plus
 
 environment:

--- a/wakelock_plus_platform_interface/CHANGELOG.md
+++ b/wakelock_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0
+
+* [#2](https://github.com/fluttercommunity/wakelock_plus/pull/2): Downgraded minimum `meta` to version `1.3.0` in order to maintain compatibility with versions of Flutter below `3.10`. Thanks [diegotori](https://github.com/diegotori).
+* **BREAKING CHANGE**: Increased the minimum supported Dart version to `2.18` in order to align it with `plugin_platform_interface`.
+
 ## 1.0.0
 
 * Initial release.

--- a/wakelock_plus_platform_interface/pubspec.yaml
+++ b/wakelock_plus_platform_interface/pubspec.yaml
@@ -7,7 +7,7 @@ repository: >-2
   https://github.com/fluttercommunity/wakelock_plus/tree/main/wakelock_plus_platform_interface
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.18.0 <4.0.0'
   flutter: ">=2.11.0"
 
 dependencies:

--- a/wakelock_plus_platform_interface/pubspec.yaml
+++ b/wakelock_plus_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: wakelock_plus_platform_interface
 description: >-2
   A common platform interface for the wakelock_plus plugin used by the different platform
   implementations.
-version: 1.0.0
+version: 1.1.0
 repository: >-2
   https://github.com/fluttercommunity/wakelock_plus/tree/main/wakelock_plus_platform_interface
 

--- a/wakelock_plus_platform_interface/pubspec.yaml
+++ b/wakelock_plus_platform_interface/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.4
-  meta: ^1.9.1
+  meta: ^1.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
In order to maintain backwards compatibility with pre-Dart 3.0, we have to downgrade `meta` to version `1.3.0`.

Also, in order to align this package with `plugin_platform_interface`, we need to increase the minimum Dart SDK version to `2.18`.

Once I receive approval, I'll publish a new version of `wakelock_plus_platform_inteface`, and possibly version it accordingly.

See https://github.com/fluttercommunity/chewie/issues/752 for more info.
