### PR TITLE
Issue #3 fix

### DIFF
--- a/wakelock_plus/android/build.gradle
+++ b/wakelock_plus/android/build.gradle
@@ -27,7 +27,10 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 33
 
-    namespace 'dev.fluttercommunity.plus.wakelock'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'dev.fluttercommunity.plus.wakelock'
+    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/wakelock_plus/example/android/app/build.gradle
+++ b/wakelock_plus/example/android/app/build.gradle
@@ -26,7 +26,12 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    namespace "dev.fluttercommunity.plus.wakelock_example"
+
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace "dev.fluttercommunity.plus.wakelock_example"
+    }
+
     compileSdkVersion 33
     ndkVersion flutter.ndkVersion
 


### PR DESCRIPTION
Android Platform Channel's Gradle scripts now conditionally set `namespace` if the property actually exists for the current Android Gradle Plugin version present.

Fixes #3.