### PR TITLE
Revert usage of package_info_plus wide version range

### DIFF
--- a/wakelock_plus/pubspec.yaml
+++ b/wakelock_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: wakelock_plus
 description: >-2
   Plugin that allows you to keep the device screen awake, i.e. prevent the screen from sleeping on
   Android, iOS, macOS, Windows, Linux, and web.
-version: 1.1.2
+version: 1.1.3
 repository: https://github.com/fluttercommunity/wakelock_plus/tree/main/wakelock_plus
 
 environment:
@@ -23,7 +23,7 @@ dependencies:
 
   # Linux dependencies
   dbus: ^0.7.8
-  package_info_plus: ">=4.0.2 <6.0.0"
+  package_info_plus: ^4.2.0
 
   # Web dependencies
   js: ^0.6.3


### PR DESCRIPTION
## Description

Version of package_info_plus 5.0.0 was retracted due to issue with Kotlin bump. 
See https://github.com/fluttercommunity/plus_plugins/issues/2251 for more context.

And since there is no guarantee that next time we introduce 5.0.0 it will be backwards compatible, I am reverting the change in `wakelock_plus` for safety reasons. 
No need to release a new update right away as there are no plans to have new breaking release of `package_info_plus` in nearest time.
