### PR TITLE
Set range for package_info_plus

### DIFF
--- a/wakelock_plus/pubspec.yaml
+++ b/wakelock_plus/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
 
   # Linux dependencies
   dbus: ^0.7.8
-  package_info_plus: ^4.2.0
+  package_info_plus: ">=4.0.2 <6.0.0"
 
   # Web dependencies
   js: ^0.6.3


### PR DESCRIPTION
## Description

`package_info_plus` version 5.x was release again, so the range can be brought back for wider compatibility. The main change in 5.x is requirement of Dart 3.2, thus, nothing critical for functionality of this package.