### PR TITLE
Upgrade package_info_plus range to ">=4.0.2 <=6.0.0"

### DIFF
--- a/wakelock_plus/pubspec.yaml
+++ b/wakelock_plus/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
 
   # Linux dependencies
   dbus: ^0.7.8
-  package_info_plus: ">=4.0.2 <6.0.0"
+  package_info_plus: ">=4.0.2 <=6.0.0"
 
   # Web dependencies
   js: ^0.7.0


### PR DESCRIPTION
## Description

This PR upgrades the `package_info_plus` package range to  `">=4.0.2 <=6.0.0"` to support the version `6.0.0` of `package_info_plus`.

#30 
