### PR TITLE
add android cpu wakelock

### DIFF
--- a/wakelock_plus/android/src/main/kotlin/dev/fluttercommunity/plus/wakelock/Messages.g.kt
+++ b/wakelock_plus/android/src/main/kotlin/dev/fluttercommunity/plus/wakelock/Messages.g.kt
@@ -122,7 +122,9 @@ private object WakelockPlusApiCodec : StandardMessageCodec() {
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface WakelockPlusApi {
   fun toggle(msg: ToggleMessage)
+  fun toggleCPU(msg: ToggleMessage)
   fun isEnabled(): IsEnabledMessage
+  fun isCPUEnabled(): IsEnabledMessage
 
   companion object {
     /** The codec used by WakelockPlusApi. */
@@ -152,12 +154,47 @@ interface WakelockPlusApi {
         }
       }
       run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggleCPU", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val msgArg = args[0] as ToggleMessage
+            var wrapped: List<Any?>
+            try {
+              api.toggleCPU(msgArg)
+              wrapped = listOf<Any?>(null)
+            } catch (exception: Throwable) {
+              wrapped = wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
         val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.isEnabled", codec)
         if (api != null) {
           channel.setMessageHandler { _, reply ->
             var wrapped: List<Any?>
             try {
               wrapped = listOf<Any?>(api.isEnabled())
+            } catch (exception: Throwable) {
+              wrapped = wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.isCPUEnabled", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            var wrapped: List<Any?>
+            try {
+              wrapped = listOf<Any?>(api.isCPUEnabled())
             } catch (exception: Throwable) {
               wrapped = wrapError(exception)
             }

--- a/wakelock_plus/android/src/main/kotlin/dev/fluttercommunity/plus/wakelock/Wakelock.kt
+++ b/wakelock_plus/android/src/main/kotlin/dev/fluttercommunity/plus/wakelock/Wakelock.kt
@@ -4,10 +4,13 @@ import IsEnabledMessage
 import ToggleMessage
 import android.app.Activity
 import android.view.WindowManager
+import android.os.PowerManager
+import android.content.Context
+
 
 internal class Wakelock {
   var activity: Activity? = null
-  val cpuWakeLock: PowerManager.WakeLock? = null
+  var cpuWakeLock: PowerManager.WakeLock? = null
 
   private val enabled
     get() = activity!!.window.attributes.flags and
@@ -42,14 +45,14 @@ internal class Wakelock {
     if (message.enable!!) {
       if (!enabled) {
         cpuWakeLock =
-        (getSystemService(Context.POWER_SERVICE) as PowerManager).run {
+        (activity?.getSystemService(Context.POWER_SERVICE) as PowerManager).run {
             newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "Vibration::KeepVibratingWakeLog").apply {
                 acquire()
             }
         }
       }
     } else if (enabled) {
-      wakelock?.release()
+      cpuWakeLock?.release()
     }
   }
 

--- a/wakelock_plus/android/src/main/kotlin/dev/fluttercommunity/plus/wakelock/WakelockPlusPlugin.kt
+++ b/wakelock_plus/android/src/main/kotlin/dev/fluttercommunity/plus/wakelock/WakelockPlusPlugin.kt
@@ -42,7 +42,16 @@ class WakelockPlusPlugin: FlutterPlugin, WakelockPlusApi, ActivityAware {
     wakelock!!.toggle(msg)
   }
 
+  override fun toggleCPU(msg: ToggleMessage) {
+    wakelock!!.toggleCPU(msg)
+  }
+
   override fun isEnabled(): IsEnabledMessage {
     return wakelock!!.isEnabled()
   }
+
+  override fun isCPUEnabled(): IsEnabledMessage {
+    return wakelock!!.isCPUEnabled()
+  }
+  
 }

--- a/wakelock_plus/ios/Classes/messages.g.h
+++ b/wakelock_plus/ios/Classes/messages.g.h
@@ -30,8 +30,11 @@ NSObject<FlutterMessageCodec> *FLTWakelockPlusApiGetCodec(void);
 
 @protocol FLTWakelockPlusApi
 - (void)toggleMsg:(FLTToggleMessage *)msg error:(FlutterError *_Nullable *_Nonnull)error;
+- (void)toggleCPUMsg:(FLTToggleMessage *)msg error:(FlutterError *_Nullable *_Nonnull)error;
 /// @return `nil` only when `error != nil`.
 - (nullable FLTIsEnabledMessage *)isEnabledWithError:(FlutterError *_Nullable *_Nonnull)error;
+/// @return `nil` only when `error != nil`.
+- (nullable FLTIsEnabledMessage *)isCPUEnabledWithError:(FlutterError *_Nullable *_Nonnull)error;
 @end
 
 extern void SetUpFLTWakelockPlusApi(id<FlutterBinaryMessenger> binaryMessenger, NSObject<FLTWakelockPlusApi> *_Nullable api);

--- a/wakelock_plus/ios/Classes/messages.g.m
+++ b/wakelock_plus/ios/Classes/messages.g.m
@@ -156,6 +156,25 @@ void SetUpFLTWakelockPlusApi(id<FlutterBinaryMessenger> binaryMessenger, NSObjec
   {
     FlutterBasicMessageChannel *channel =
       [[FlutterBasicMessageChannel alloc]
+        initWithName:@"dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggleCPU"
+        binaryMessenger:binaryMessenger
+        codec:FLTWakelockPlusApiGetCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(toggleCPUMsg:error:)], @"FLTWakelockPlusApi api (%@) doesn't respond to @selector(toggleCPUMsg:error:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        NSArray *args = message;
+        FLTToggleMessage *arg_msg = GetNullableObjectAtIndex(args, 0);
+        FlutterError *error;
+        [api toggleCPUMsg:arg_msg error:&error];
+        callback(wrapResult(nil, error));
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
         initWithName:@"dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.isEnabled"
         binaryMessenger:binaryMessenger
         codec:FLTWakelockPlusApiGetCodec()];
@@ -164,6 +183,23 @@ void SetUpFLTWakelockPlusApi(id<FlutterBinaryMessenger> binaryMessenger, NSObjec
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
         FLTIsEnabledMessage *output = [api isEnabledWithError:&error];
+        callback(wrapResult(output, error));
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:@"dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.isCPUEnabled"
+        binaryMessenger:binaryMessenger
+        codec:FLTWakelockPlusApiGetCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(isCPUEnabledWithError:)], @"FLTWakelockPlusApi api (%@) doesn't respond to @selector(isCPUEnabledWithError:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        FlutterError *error;
+        FLTIsEnabledMessage *output = [api isCPUEnabledWithError:&error];
         callback(wrapResult(output, error));
       }];
     } else {

--- a/wakelock_plus/lib/wakelock_plus.dart
+++ b/wakelock_plus/lib/wakelock_plus.dart
@@ -40,6 +40,17 @@ class WakelockPlus {
   /// * [toggle], which allows to enable or disable using a [bool] parameter.
   static Future<void> enable() => toggle(enable: true);
 
+  /// Enables the CPU-wakelock.
+  /// CURRENTLY ONLY AVAILABLE ON ANDROID
+  ///
+  /// This can simply be called using `WakelockPlus.enableCPU()` and does not return
+  /// anything.
+  /// You can await the [Future] to wait for the operation to complete.
+  ///
+  /// See also:
+  /// * [toggleCPU], which allows to enable or disable using a [bool] parameter.
+  static Future<void> enableCPU() => toggleCPU(enable: true);
+
   /// Disables the wakelock.
   ///
   /// This can simply be called using `WakelockPlus.disable()` and does not return
@@ -49,6 +60,18 @@ class WakelockPlus {
   /// See also:
   /// * [toggle], which allows to enable or disable using a [bool] parameter.
   static Future<void> disable() => toggle(enable: false);
+
+  /// Disables the CPU-wakelock.
+  /// CURRENTLY ONLY AVAILABLE ON ANDROID
+  ///
+  /// This can simply be called using `WakelockPlus.disableCPU()` and does not return
+  /// anything.
+  /// You can await the [Future] to wait for the operation to complete.
+  ///
+  /// See also:
+  /// * [toggleCPU], which allows to enable or disable using a [bool] parameter.
+  static Future<void> disableCPU() => toggleCPU(enable: false);
+
 
   /// Toggles the wakelock on or off.
   ///
@@ -71,6 +94,28 @@ class WakelockPlus {
     return wakelockPlusPlatformInstance.toggle(enable: enable);
   }
 
+  /// Toggles the CPU-wakelock on or off.
+  /// CURRENTLY ONLY AVAILABLE ON ANDROID
+  ///
+  /// You can simply use this function to toggle the CPU-wakelock using a [bool]
+  /// value (for the [enable] parameter).
+  ///
+  /// ```dart
+  /// // This line keeps the CPU on.
+  /// WakelockPlus.toggleCPU(enable: true);
+  ///
+  /// bool enableWakelock = false;
+  /// // The following line disables the WakelockPlus.
+  /// WakelockPlus.toggleCPU(enable: enableWakelock);
+  /// ```
+  ///
+  /// You can await the [Future] to wait for the operation to complete.
+  static Future<void> toggleCPU({
+    required bool enable,
+  }) {
+    return wakelockPlusPlatformInstance.toggleCPU(enable: enable);
+  }
+
   /// Returns whether the wakelock is currently enabled or not.
   ///
   /// If you want to retrieve the current wakelock status, you will have to call
@@ -80,4 +125,16 @@ class WakelockPlus {
   /// bool wakelockEnabled = await WakelockPlus.enabled;
   /// ```
   static Future<bool> get enabled => wakelockPlusPlatformInstance.enabled;
+
+  /// Returns whether the CPU-wakelock is currently enabled or not.
+  /// CURRENTLY ONLY AVAILABLE ON ANDROID
+  ///
+  /// If you want to retrieve the current CPU-wakelock status, you will have to call
+  /// [WakelockPlus.enabledCPU] and await its result:
+  ///
+  /// ```dart
+  /// bool wakelockEnabled = await WakelockPlus.enabledCPU;
+  /// ```
+  static Future<bool> get enabledCPU => wakelockPlusPlatformInstance.enabledCPU;
+
 }

--- a/wakelock_plus/pigeons/messages.dart
+++ b/wakelock_plus/pigeons/messages.dart
@@ -25,6 +25,8 @@ class IsEnabledMessage {
 @HostApi(dartHostTestHandler: 'TestWakelockPlusApi')
 abstract class WakelockPlusApi {
   void toggle(ToggleMessage msg);
+  void toggleCPU(ToggleMessage msg);
 
   IsEnabledMessage isEnabled();
+  IsEnabledMessage isCPUEnabled();
 }

--- a/wakelock_plus/pubspec.yaml
+++ b/wakelock_plus/pubspec.yaml
@@ -17,7 +17,8 @@ dependencies:
   meta: ^1.3.0
   wakelock_plus_platform_interface: #^1.1.1
     git:
-      url: https://github.com/hannesgithub/wakelock_plus/wakelock_plus_platform_interface
+      url: https://github.com/hannesgith/wakelock_plus
+      path: wakelock_plus_platform_interface
 
   # Windows dependencies
   # win32 is compatible across v4 and v5 for Win32 only (not COM)

--- a/wakelock_plus/pubspec.yaml
+++ b/wakelock_plus/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   meta: ^1.3.0
   wakelock_plus_platform_interface: #^1.1.1
     git:
-      url: https://github.com/hannesgith/wakelock_plus
+      url: https://github.com/fluttercommunity/wakelock_plus
       path: wakelock_plus_platform_interface
 
   # Windows dependencies

--- a/wakelock_plus/pubspec.yaml
+++ b/wakelock_plus/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   meta: ^1.3.0
-  wakelock_plus_platform_interface: ^1.2.0
+  wakelock_plus_platform_interface: ^1.2.1
 
   # Windows dependencies
   # win32 is compatible across v4 and v5 for Win32 only (not COM)

--- a/wakelock_plus/pubspec.yaml
+++ b/wakelock_plus/pubspec.yaml
@@ -15,7 +15,9 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   meta: ^1.3.0
-  wakelock_plus_platform_interface: ^1.2.1
+  wakelock_plus_platform_interface: #^1.1.1
+    git:
+      url: https://github.com/hannesgithub/wakelock_plus/wakelock_plus_platform_interface
 
   # Windows dependencies
   # win32 is compatible across v4 and v5 for Win32 only (not COM)

--- a/wakelock_plus_platform_interface/lib/messages.g.dart
+++ b/wakelock_plus_platform_interface/lib/messages.g.dart
@@ -88,9 +88,9 @@ class _WakelockPlusApiCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 128:
+      case 128: 
         return IsEnabledMessage.decode(readValue(buffer)!);
-      case 129:
+      case 129: 
         return ToggleMessage.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -109,20 +109,35 @@ class WakelockPlusApi {
   static const MessageCodec<Object?> pigeonChannelCodec =
       _WakelockPlusApiCodec();
 
-  Future<void> toggle(ToggleMessage msg) async {
-    const String __pigeon_channelName =
-        'dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggle';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
-      __pigeon_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: __pigeon_binaryMessenger,
-    );
-    final List<Object?>? __pigeon_replyList =
-        await __pigeon_channel.send(<Object?>[msg]) as List<Object?>?;
-    if (__pigeon_replyList == null) {
-      throw _createConnectionError(__pigeon_channelName);
-    } else if (__pigeon_replyList.length > 1) {
+  Future<void> toggle(ToggleMessage arg_msg) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggle', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_msg]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<void> toggleCPU(ToggleMessage arg_msg) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggleCPU', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_msg]) as List<Object?>?;
+    if (replyList == null) {
       throw PlatformException(
         code: __pigeon_replyList[0]! as String,
         message: __pigeon_replyList[1] as String?,
@@ -134,6 +149,7 @@ class WakelockPlusApi {
   }
 
   Future<IsEnabledMessage> isEnabled() async {
+<<<<<<< HEAD
     const String __pigeon_channelName =
         'dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.isEnabled';
     final BasicMessageChannel<Object?> __pigeon_channel =
@@ -147,6 +163,41 @@ class WakelockPlusApi {
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {
+=======
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.isEnabled', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(null) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as IsEnabledMessage?)!;
+    }
+  }
+
+  Future<IsEnabledMessage> isCPUEnabled() async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.isCPUEnabled', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(null) as List<Object?>?;
+    if (replyList == null) {
+>>>>>>> c0d2bef (added preliminary cpu wakelock)
       throw PlatformException(
         code: __pigeon_replyList[0]! as String,
         message: __pigeon_replyList[1] as String?,

--- a/wakelock_plus_platform_interface/lib/wakelock_plus_platform_interface.dart
+++ b/wakelock_plus_platform_interface/lib/wakelock_plus_platform_interface.dart
@@ -43,9 +43,19 @@ abstract class WakelockPlusPlatformInterface extends PlatformInterface {
     throw UnimplementedError('toggle() has not been implemented.');
   }
 
+  /// Toggles the CPU wakelock based on the given [enable] value.
+  Future<void> toggleCPU({required bool enable}) {
+    throw UnimplementedError('toggleCPU() has not been implemented.');
+  }
+
   /// Returns whether the wakelock is enabled or not.
   Future<bool> get enabled {
     throw UnimplementedError('isEnabled has not been implemented.');
+  }
+
+  /// Returns whether the CPU wakelock is enabled or not.
+  Future<bool> get enabledCPU {
+    throw UnimplementedError('isEnabledCPU has not been implemented.');
   }
 
   // This method makes sure that VideoPlayer isn't implemented with `implements`.

--- a/wakelock_plus_platform_interface/pubspec.yaml
+++ b/wakelock_plus_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: wakelock_plus_platform_interface
 description: >-2
   A common platform interface for the wakelock_plus plugin used by the different platform
   implementations.
-version: 1.2.0
+version: 1.2.1
 repository: >-2
   https://github.com/fluttercommunity/wakelock_plus/tree/main/wakelock_plus_platform_interface
 

--- a/wakelock_plus_platform_interface/test/messages.g.dart
+++ b/wakelock_plus_platform_interface/test/messages.g.dart
@@ -28,9 +28,9 @@ class _TestWakelockPlusApiCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 128:
+      case 128: 
         return IsEnabledMessage.decode(readValue(buffer)!);
-      case 129:
+      case 129: 
         return ToggleMessage.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -39,70 +39,81 @@ class _TestWakelockPlusApiCodec extends StandardMessageCodec {
 }
 
 abstract class TestWakelockPlusApi {
-  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
-      TestDefaultBinaryMessengerBinding.instance;
-  static const MessageCodec<Object?> pigeonChannelCodec =
-      _TestWakelockPlusApiCodec();
+  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding => TestDefaultBinaryMessengerBinding.instance;
+  static const MessageCodec<Object?> codec = _TestWakelockPlusApiCodec();
 
   void toggle(ToggleMessage msg);
 
+  void toggleCPU(ToggleMessage msg);
+
   IsEnabledMessage isEnabled();
 
-  static void setup(TestWakelockPlusApi? api,
-      {BinaryMessenger? binaryMessenger}) {
+  IsEnabledMessage isCPUEnabled();
+
+  static void setup(TestWakelockPlusApi? api, {BinaryMessenger? binaryMessenger}) {
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggle',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggle', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(__pigeon_channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(__pigeon_channel,
-                (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggle was null.');
+          'Argument for dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggle was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final ToggleMessage? arg_msg = (args[0] as ToggleMessage?);
           assert(arg_msg != null,
               'Argument for dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggle was null, expected non-null ToggleMessage.');
-          try {
-            api.toggle(arg_msg!);
-            return wrapResponse(empty: true);
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
-          }
+          api.toggle(arg_msg!);
+          return <Object?>[];
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.isEnabled',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggleCPU', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(__pigeon_channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger
-            .setMockDecodedMessageHandler<Object?>(__pigeon_channel,
-                (Object? message) async {
-          try {
-            final IsEnabledMessage output = api.isEnabled();
-            return <Object?>[output];
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
-          }
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+          assert(message != null,
+          'Argument for dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggleCPU was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final ToggleMessage? arg_msg = (args[0] as ToggleMessage?);
+          assert(arg_msg != null,
+              'Argument for dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.toggleCPU was null, expected non-null ToggleMessage.');
+          api.toggleCPU(arg_msg!);
+          return <Object?>[];
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.isEnabled', codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+          // ignore message
+          final IsEnabledMessage output = api.isEnabled();
+          return <Object?>[output];
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.wakelock_plus_platform_interface.WakelockPlusApi.isCPUEnabled', codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+          // ignore message
+          final IsEnabledMessage output = api.isCPUEnabled();
+          return <Object?>[output];
         });
       }
     }


### PR DESCRIPTION
## Description

simply adds a new variant with CPU suffix to the api, toggling the android [cpu wakelock](https://developer.android.com/develop/background-work/background-tasks/scheduling/wakelock#cpu)

i.e. in addition to `WakelockPlus.toggle(..)` we can now also use `WakelockPlus.toggleCPU(..)` etc.