### PR TITLE
chore(deps): Allow web ^1.0.0

### DIFF
--- a/wakelock_plus/pubspec.yaml
+++ b/wakelock_plus/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   package_info_plus: ">=6.0.0 <9.0.0"
 
   # Web dependencies
-  web: ^0.5.1
+  web: ">=0.5.1 <2.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

Allows web ^1.0.0 without any breaking changes as the used API elements did not change since ^0.5.1.

Closes https://github.com/fluttercommunity/wakelock_plus/issues/68
