### PR TITLE
fix: deprecated orientation

### DIFF
--- a/wakelock_plus/example/ios/Runner/Info.plist
+++ b/wakelock_plus/example/ios/Runner/Info.plist
@@ -41,8 +41,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>


### PR DESCRIPTION
## Description

The example app no longer supports iOS 9 so this orientation code isn't needed
https://developer.apple.com/documentation/uikit/uiapplication/1623026-statusbarorientation?language=objc
