### PR TITLE
fix: add support for non-root base-href

### DIFF
--- a/wakelock_plus/lib/src/web_impl/import_js_library.dart
+++ b/wakelock_plus/lib/src/web_impl/import_js_library.dart
@@ -1,4 +1,5 @@
 import 'dart:js_interop';
+import 'dart:ui_web';
 
 import 'package:web/web.dart';
 
@@ -20,10 +21,10 @@ Future<void> importJsLibrary(
 String _libraryUrl(String url, String pluginName) {
   if (url.startsWith('./')) {
     url = url.replaceFirst('./', '');
-    return './assets/packages/$pluginName/$url';
+    return assetManager.getAssetUrl("packages/$pluginName/$url");
   }
   if (url.startsWith('assets/')) {
-    return './assets/packages/$pluginName/$url';
+    return assetManager.getAssetUrl("packages/$pluginName/$url");
   } else {
     return url;
   }


### PR DESCRIPTION
## Description

if a web-app is deployed using `--base-href=/path/to/deployed/flutter/app` during build, the URLs starting with `./assets` won't work anymore. Using [assetManager](https://api.flutter.dev/flutter/dart-ui_web/assetManager.html) will properly resolve them. It uses `assetBase` from the loader config specified [here](https://docs.flutter.dev/platform-integration/web/initialization#the-_flutter-loader-load-api)

## NB :warning:
I only tested the `url.startsWith('assets/')` code path as it's the only one used in the library. It should work the same for `./` though