### PR TITLE
fixed resource bundle name in podspec

### DIFF
--- a/wakelock_plus/ios/wakelock_plus.podspec
+++ b/wakelock_plus/ios/wakelock_plus.podspec
@@ -20,5 +20,5 @@ Plugin that allows you to keep the device screen awake, i.e. prevent the screen 
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
-  s.resource_bundles = {'thermal' => ['Resources/PrivacyInfo.xcprivacy']}
+  s.resource_bundles = {'wakelock_plus_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
Fixes the privacy resource bundle name not to collide with [thermal](https://github.com/muxable/flutter_thermal/blob/bd54ae26e315008c88b300fdaec4df8362fa8aa9/ios/thermal.podspec#L23) package