### PR TITLE
fix(ios): fix path to PrivacyInfo.xcprivacy

### DIFF
--- a/wakelock_plus/ios/wakelock_plus/Package.swift
+++ b/wakelock_plus/ios/wakelock_plus/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
             name: "wakelock_plus",
             dependencies: [],
             resources: [
-                .process("PrivacyInfo.xcprivacy"),
+                .process("Resources")
             ],
             cSettings: [
                 .headerSearchPath("include/wakelock_plus")


### PR DESCRIPTION
### 🛠️ What this PR does

This PR fixes an Xcode warning related to a missing `PrivacyInfo.xcprivacy` file:

```Invalid Resource 'PrivacyInfo.xcprivacy': File not found.```

While this warning does **not** prevent the build from succeeding, it does show up in Xcode under "All Issues" and can be confusing or concerning to developers.

### ✅ Fix

Corrected the path to `PrivacyInfo.xcprivacy` so that Xcode can locate it properly in the `Resources` folder. This eliminates unnecessary warnings in Xcode.

Let me know if you'd like any changes — and thank you for maintaining this plugin!
