### PR TITLE
return IsEnabledMessage(false) when activity is null instead of throwing an exception

### DIFF
--- a/wakelock_plus/android/src/main/kotlin/dev/fluttercommunity/plus/wakelock/Wakelock.kt
+++ b/wakelock_plus/android/src/main/kotlin/dev/fluttercommunity/plus/wakelock/Wakelock.kt
@@ -29,7 +29,7 @@ internal class Wakelock {
 
   fun isEnabled(): IsEnabledMessage {
     if (activity == null) {
-      throw NoActivityException()
+      return IsEnabledMessage(enabled = false)
     }
 
     return IsEnabledMessage(enabled = enabled)


### PR DESCRIPTION
Suggesting to return `IsEnabledMessage(false)` when activity is null inside `isEnabled()`,
to avoid crashes and allow `isEnabled()` to be used as a guard before calling enable/disable while the app is in the background.